### PR TITLE
Fix audio beeps not working after iPhone sleep during pause

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -25,15 +25,14 @@ export class Timer {
   }
 
   async initializeAudio() {
-    if (!this.audioInitialized) {
-      try {
-        await this.beep.play()
-        this.beep.pause()
-        this.beep.currentTime = 0
-        this.audioInitialized = true
-      } catch (error) {
-        console.log('Audio initialization failed:', error)
-      }
+    try {
+      await this.beep.play()
+      this.beep.pause()
+      this.beep.currentTime = 0
+      this.audioInitialized = true
+    } catch (error) {
+      console.log('Audio initialization failed:', error)
+      this.audioInitialized = false
     }
   }
 
@@ -113,6 +112,7 @@ export class Timer {
 
   resume() {
     if (this.isPaused) {
+      this.initializeAudio()
       this.start()
       this.isPaused = false
       this.pauseResumeBtn.innerHTML = 'Pause'


### PR DESCRIPTION
## Summary
- Fixes audio beeps not playing after resuming from pause when iPhone has slept
- Removes guard condition from initializeAudio() to allow re-initialization
- Re-initializes audio when resuming to reactivate suspended audio context

## Issue
When pausing the timer and letting the iPhone sleep, iOS Safari suspends the audio context to save battery. Upon resuming, the beeps would no longer play because the audio context remained suspended.

## Test plan
- [ ] Pause timer on iPhone and let device sleep
- [ ] Resume timer and verify beeps play correctly at countdown intervals
- [ ] Test multiple pause/resume cycles after sleep