### PR TITLE
Fix GitHub Pages routing - use relative path for timer redirect

### DIFF
--- a/kettlebell-timer/src/index.js
+++ b/kettlebell-timer/src/index.js
@@ -16,5 +16,5 @@ workouts.forEach((workout, i) => {
 
 workoutSelectorButton.addEventListener('click', (e) => {
   console.log('Selected workout index >>>', workoutSelect.value);
-  window.location.href = "/kettlebell-timer/timer.html?w=" + workoutSelect.value;
+  window.location.href = "timer.html?w=" + workoutSelect.value;
 })


### PR DESCRIPTION
Changed redirect from absolute path "/kettlebell-timer/timer.html" to relative path "timer.html". This fixes 404 errors on GitHub Pages where the app is served from a subdirectory.

- Works on localhost: localhost:8080/kettlebell-timer/timer.html
- Works on GH Pages: username.github.io/repo-name/kettlebell-timer/timer.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)